### PR TITLE
Fixes the issue of unsupported notation

### DIFF
--- a/sipvicious/libs/svhelper.py
+++ b/sipvicious/libs/svhelper.py
@@ -704,8 +704,10 @@ def ip4range(*args):
 
 
 def ip6range(*args):
+    log = logging.getLogger('ip6range')
     for arg in args:
-        yield(arg)
+        if check_ipv6(arg):
+            yield(arg)
 
 
 def getranges(ipstring):
@@ -1151,6 +1153,10 @@ def getAuthHeader(pkt):
 
 
 def check_ipv6(n):
+    log = logging.getLogger('check_ipv6')
+    if '/' in n:
+        log.error('CIDR notation not supported for IPv6 addresses.')
+        return False
     try:
         socket.inet_pton(socket.AF_INET6, n)
         return True

--- a/sipvicious/libs/svhelper.py
+++ b/sipvicious/libs/svhelper.py
@@ -704,7 +704,6 @@ def ip4range(*args):
 
 
 def ip6range(*args):
-    log = logging.getLogger('ip6range')
     for arg in args:
         if check_ipv6(arg):
             yield(arg)


### PR DESCRIPTION
Fixes #59.

Pasting output for easier interpretation.
```
$ sipvicious_svmap -6 2a10:1::/24 -v
```
```
INFO:DrinkOrSip:trying to get self ip .. might take a while
INFO:root:start your engines
ERROR:check_ipv6:CIDR notation not supported for IPv6 addresses.
WARNING:root:found nothing
INFO:root:Total time: 0:00:03.014660
```