### PR TITLE
Adding fixes for port input

### DIFF
--- a/sipvicious/libs/svhelper.py
+++ b/sipvicious/libs/svhelper.py
@@ -54,8 +54,6 @@ def standardoptions(parser):
                       help="Increase verbosity")
     parser.add_option('-q', '--quiet', dest="quiet", action="store_true",
                       default=False, help="Quiet mode")
-    parser.add_option("-p", "--port", dest="port", default="5060",
-                      help="Destination port or port ranges of the SIP device - eg -p5060,5061,8000-8100", metavar="PORT")
     parser.add_option("-P", "--localport", dest="localport", default=5060, type="int",
                       help="Source port for our packets", metavar="PORT")
     parser.add_option("-x", "--externalip", dest="externalip",

--- a/sipvicious/svcrack.py
+++ b/sipvicious/svcrack.py
@@ -81,7 +81,12 @@ class ASipOfRedWine:
         self.challenges = list()
         self.crackmode = crackmode
         self.crackargs = crackargs
-        self.dsthost, self.dstport = host, int(port)
+        try:
+            if int(port) > 1 and int(port) <= 65535:
+                self.dsthost, self.dstport = host, int(port)
+        except (ValueError, TypeError):
+            self.log.error('port should strictly be an integer between 1 and 65535')
+            exit(1)
         self.domain = self.dsthost
         if domain:
             self.domain = domain
@@ -362,6 +367,8 @@ def main():
     usage += "%prog -u100 -r1-9999 -z4 10.0.0.1\r\n"
     parser = OptionParser(usage, version="%prog v" +
                           str(__version__) + __GPL__)
+    parser.add_option("-p", "--port", dest="port", default="5060",
+                      help="Destination port of the SIP device - eg -p 5060", metavar="PORT")
     parser = standardoptions(parser)
     parser = standardscanneroptions(parser)
     parser.add_option("-u", "--username", dest="username",

--- a/sipvicious/svcrash.py
+++ b/sipvicious/svcrash.py
@@ -23,6 +23,7 @@ __GPL__ = """
 import re
 import sys
 import time
+import scapy
 import logging
 import optparse
 import os.path

--- a/sipvicious/svmap.py
+++ b/sipvicious/svmap.py
@@ -304,6 +304,8 @@ def main():
     usage += "%prog --resume session1 -v\r\n\r\n"
     usage += "%prog -p5060-5062 10.0.0.3-20 -m INVITE\r\n\r\n"
     parser = OptionParser(usage, version="%prog v"+str(__version__)+__GPL__)
+    parser.add_option("-p", "--port", dest="port", default="5060",
+                      help="Destination port or port ranges of the SIP device - eg -p5060,5061,8000-8100", metavar="PORT")
     parser = standardoptions(parser)
     parser = standardscanneroptions(parser)
     parser.add_option("--randomscan", dest="randomscan", action="store_true",

--- a/sipvicious/svwar.py
+++ b/sipvicious/svwar.py
@@ -82,7 +82,12 @@ class TakeASip:
         self.xlist = list()
         self.challenges = list()
         self.realm = None
-        self.dsthost, self.dstport = host, int(port)
+        try:
+            if int(port) > 1 and int(port) <= 65535:
+                self.dsthost, self.dstport = host, int(port)
+        except (ValueError, TypeError):
+            self.log.error('port should strictly be an integer between 1 and 65535')
+            exit(1)
         self.domain = self.dsthost
         if domain:
             self.domain = domain
@@ -465,6 +470,8 @@ def main():
     usage += "%prog -d dictionary.txt 10.0.0.2\r\n"
     parser = OptionParser(usage, version="%prog v" +
                           str(__version__) + __GPL__)
+    parser.add_option("-p", "--port", dest="port", default="5060",
+                      help="Destination port of the SIP device - eg -p 5060", metavar="PORT")
     parser = standardoptions(parser)
     parser = standardscanneroptions(parser)
     parser.add_option("-d", "--dictionary", dest="dictionary", type="string",


### PR DESCRIPTION
This PR addresses the following:
- [x] handle try catch for ports that are not integers in svwar/svcrack.
- [x] update the `standardscanneroptions()` function to remove the port argument.
- [x] add the port flag individually for each tool with its specific help for `svmap`, `svwar`, `svcrack`.