### PR TITLE
Input via STDIN for svcrack & svwar

### DIFF
--- a/sipvicious/libs/svhelper.py
+++ b/sipvicious/libs/svhelper.py
@@ -329,7 +329,7 @@ def parseHeader(buff, type='response'):
             #if len(_t) == 3:
             #    method, uri, sipversion = _t
         else:
-            log.warn('Could not parse the first header line: %s' % _t.__repr__())
+            log.warn('Could not parse the first header line: %s' % headerlines[0])
             return r
         r['headers'] = dict()
         for headerline in headerlines[1:]:
@@ -429,11 +429,7 @@ def getToTag(buff):
 
 
 def challengeResponse(auth, method, uri):
-    try:
-        from hashlib import md5
-    except ImportError:
-        import md5 as md5sum
-        md5 = md5sum.new
+    from hashlib import md5
     username = auth["username"]
     realm = auth["realm"]
     passwd = auth["password"]

--- a/sipvicious/libs/svhelper.py
+++ b/sipvicious/libs/svhelper.py
@@ -25,7 +25,6 @@ __version__ = '0.3.1'
 import re
 import sys
 import uuid
-import base64
 import os
 import dbm
 import socket
@@ -33,8 +32,6 @@ import random
 import struct
 import shutil
 import logging
-import optparse
-from urllib.parse import quote
 from random import getrandbits
 from urllib.request import urlopen
 from urllib.error import URLError
@@ -182,6 +179,7 @@ def dictionaryattack(dictionaryfile):
         if len(r) == 0:
             break
         yield(r.strip())
+    dictionaryfile.flush()
     dictionaryfile.close()
 
 
@@ -443,7 +441,7 @@ def challengeResponse(auth, method, uri):
     opaque = auth["opaque"]
     algorithm = auth["algorithm"]
     cnonce = ""
-    qop = None  
+    qop = None
     if auth["qop"] != None:
         qop = auth["qop"].split(',')[0]
     result = 'Digest username="%s",realm="%s",nonce="%s",uri="%s"' % (

--- a/sipvicious/svcrack.py
+++ b/sipvicious/svcrack.py
@@ -19,12 +19,12 @@ __GPL__ = """
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import base64
 import logging
 import dbm
 import random
 import select
 import socket
+import sys
 import time
 import os
 import pickle
@@ -35,7 +35,7 @@ from optparse import OptionParser
 from sipvicious.libs.pptable import to_string
 from sipvicious.libs.svhelper import ( __version__, mysendto, reportBugToAuthor,
     numericbrute, dictionaryattack, packetcounter, check_ipv6,
-    createTag, makeRequest, getAuthHeader, getNonce, getOpaque, 
+    createTag, makeRequest, getAuthHeader, getNonce, getOpaque,
     getAlgorithm, getQop, getCID, getRealm, getCredentials, getRange,
     standardscanneroptions, standardoptions, calcloglevel, resumeFrom
 )
@@ -44,8 +44,7 @@ __prog__ = 'svcrack'
 
 class ASipOfRedWine:
 
-    def __init__(self, host='localhost', bindingip='', localport=5060, port=5060,
-                 externalip=None,
+    def __init__(self, host='localhost', bindingip='', localport=5060, port=5060, externalip=None,
                  username=None, crackmode=1, crackargs=None, realm=None, sessionpath=None,
                  selecttime=0.005, compact=False, reusenonce=False, extension=None,
                  maxlastrecvtime=10, domain=None, requesturi=None, method='REGISTER', ipv6=False):
@@ -114,7 +113,7 @@ class ASipOfRedWine:
         self.localport = localport
         self.requesturi = requesturi
         self.noncecount = 1
-        self.originallocalport = localport        
+        self.originallocalport = localport
         if self.sessionpath is not None:
             self.packetcount = packetcounter(50)
         if externalip is None:
@@ -455,14 +454,17 @@ def main():
 
     if options.dictionary is not None:
         crackmode = 2
-        try:
-            dictionary = open(options.dictionary, 'r', encoding='utf-8', errors='ignore')
-        except IOError:
-            logging.error("could not open %s" % options.dictionary)
-        if options.resume is not None:
-            lastpasswdsrc = os.path.join(exportpath, 'lastpasswd.pkl')
-            previousposition = pickle.load(open(lastpasswdsrc, 'rb'), encoding='bytes')
-            dictionary.seek(previousposition)
+        if options.dictionary == "-":
+            dictionary = sys.stdin
+        else:
+            try:
+                dictionary = open(options.dictionary, 'r', encoding='utf-8', errors='ignore')
+            except IOError:
+                logging.error("could not open %s" % options.dictionary)
+            if options.resume is not None:
+                lastpasswdsrc = os.path.join(exportpath, 'lastpasswd.pkl')
+                previousposition = pickle.load(open(lastpasswdsrc, 'rb'), encoding='bytes')
+                dictionary.seek(previousposition)
         crackargs = dictionary
     else:
         crackmode = 1

--- a/sipvicious/svcrack.py
+++ b/sipvicious/svcrack.py
@@ -371,7 +371,7 @@ def main():
     parser.add_option("-u", "--username", dest="username",
                       help="username to try crack", metavar="USERNAME")
     parser.add_option("-d", "--dictionary", dest="dictionary", type="string",
-                      help="specify a dictionary file with passwords",
+                      help="specify a dictionary file with passwords or - for stdin",
                       metavar="DICTIONARY")
     parser.add_option("-r", "--range", dest="range", default="100-999",
                       help="specify a range of numbers. example: 100-200,300-310,400",

--- a/sipvicious/svcrack.py
+++ b/sipvicious/svcrack.py
@@ -428,22 +428,6 @@ def main():
             '~'), '.sipvicious', __prog__, options.save)
         logging.debug('Session path: %s' % exportpath)
 
-    if options.resume is not None:
-        exportpath = os.path.join(os.path.expanduser(
-            '~'), '.sipvicious', __prog__, options.resume)
-        if not os.path.exists(exportpath):
-            logging.critical(
-                'A session with the name %s was not found' % options.resume)
-            exit(1)
-        optionssrc = os.path.join(exportpath, 'options.pkl')
-        previousresume = options.resume
-        previousverbose = options.verbose
-        options, args = pickle.load(open(optionssrc, 'rb'), encoding='bytes')
-        options.resume = previousresume
-        options.verbose = previousverbose
-    elif options.save is not None:
-        exportpath = os.path.join(os.path.expanduser(
-            '~'), '.sipvicious', __prog__, options.save)
     if len(args) != 1:
         parser.error("provide one hostname")
     else:

--- a/sipvicious/svwar.py
+++ b/sipvicious/svwar.py
@@ -24,20 +24,18 @@ import random
 import select
 import pickle
 import socket
+import sys
 import time
 import dbm
 import os
-import re
 import traceback
 from sys import exit
 from optparse import OptionParser
 from datetime import datetime
-from socket import error as socketerror
-from base64 import b64decode, b64encode
 from sipvicious.libs.pptable import to_string
 from sipvicious.libs.svhelper import (
     __version__, numericbrute, dictionaryattack, mysendto,
-    createTag, check_ipv6, makeRequest, getTag, parseHeader, 
+    createTag, check_ipv6, makeRequest, getTag, parseHeader,
     getRealm, standardoptions, standardscanneroptions, calcloglevel,
     resumeFrom, getRange, reportBugToAuthor, packetcounter
 )
@@ -154,7 +152,7 @@ class TakeASip:
     # try with the next one.
     SERVICEUN = 'SIP/2.0 503 '
 
-    def createRequest(self, m, username=None, auth=None, cid=None, 
+    def createRequest(self, m, username=None, auth=None, cid=None,
                         cseq=1, fromaddr=None, toaddr=None, contact=None):
         if cid is None:
             cid = '%s' % str(random.getrandbits(32))
@@ -552,15 +550,18 @@ def main():
         host = args[0]
     if options.dictionary is not None:
         guessmode = 2
-        try:
-            dictionary = open(options.dictionary, 'r', encoding='utf-8', errors='ignore')
-        except IOError:
-            logging.error("could not open %s" % options.dictionary)
-            exit(1)
-        if options.resume is not None:
-            lastextensionsrc = os.path.join(exportpath, 'lastextension.pkl')
-            previousposition = pickle.load(open(lastextensionsrc, 'rb'), encoding='bytes')
-            dictionary.seek(previousposition)
+        if options.dictionary == "-":
+            dictionary = sys.stdin
+        else:
+            try:
+                dictionary = open(options.dictionary, 'r', encoding='utf-8', errors='ignore')
+            except IOError:
+                logging.error("could not open %s" % options.dictionary)
+                exit(1)
+            if options.resume is not None:
+                lastextensionsrc = os.path.join(exportpath, 'lastextension.pkl')
+                previousposition = pickle.load(open(lastextensionsrc, 'rb'), encoding='bytes')
+                dictionary.seek(previousposition)
         guessargs = dictionary
     else:
         guessmode = 1
@@ -669,7 +670,7 @@ def main():
                         rows.append((k.decode(), sipvicious.resultauth[k].decode()))
                 except AttributeError:
                     for k in sipvicious.resultauth.keys():
-                        rows.append((k, sipvicious.resultauth[k]))                    
+                        rows.append((k, sipvicious.resultauth[k]))
                 print(to_string(rows, header=labels))
             else:
                 logging.warning("too many to print - use svreport for this")

--- a/sipvicious/svwar.py
+++ b/sipvicious/svwar.py
@@ -473,7 +473,7 @@ def main():
     parser = standardoptions(parser)
     parser = standardscanneroptions(parser)
     parser.add_option("-d", "--dictionary", dest="dictionary", type="string",
-                      help="specify a dictionary file with possible extension names",
+                      help="specify a dictionary file with possible extension names or - for stdin",
                       metavar="DICTIONARY")
     parser.add_option("-m", "--method", dest="method", type="string",
                       help="specify a request method. The default is REGISTER. Other possible methods are OPTIONS and INVITE",


### PR DESCRIPTION
### Objective:
This PR addresses the following:
- [x] svwar and svcrack now takes in input from stdin using the `--dictionary -`.
- [x] Other quick bug fixes and stuff.

### Output:
A quick output from the tool `svwar`:
```bash
$ maskprocessor '?d?d?d?d' | sipvicious_svwar demo.sipvicious.pro -v -d -
INFO:TakeASip:trying to get self ip .. might take a while
INFO:root:start your engines
INFO:TakeASip:Ok SIP device found
INFO:TakeASip:extension '1000' exists - requires authentication
INFO:TakeASip:extension '1001' exists - requires authentication
INFO:TakeASip:extension '1002' exists - requires authentication
INFO:TakeASip:extension '1003' exists - requires authentication
INFO:TakeASip:extension '1004' exists - requires authentication
INFO:TakeASip:extension '1005' exists - requires authentication
INFO:TakeASip:extension '1006' exists - requires authentication
INFO:TakeASip:extension '1007' exists - requires authentication
INFO:TakeASip:extension '1008' exists - requires authentication
INFO:TakeASip:extension '1009' exists - requires authentication
INFO:TakeASip:extension '1100' exists - requires authentication
INFO:TakeASip:extension '1200' exists - requires authentication
INFO:TakeASip:extension '1300' exists - requires authentication
INFO:TakeASip:extension '1400' exists - requires authentication
INFO:TakeASip:extension '2000' exists - requires authentication
INFO:root:we have 15 extensions
+-----------+----------------+
| Extension | Authentication |
+===========+================+
| 1000      | reqauth        |
+-----------+----------------+
| 1001      | reqauth        |
+-----------+----------------+
| 1002      | reqauth        |
+-----------+----------------+
| 1003      | reqauth        |
+-----------+----------------+
| 1004      | reqauth        |
+-----------+----------------+
| 1005      | reqauth        |
+-----------+----------------+
| 1006      | reqauth        |
+-----------+----------------+
| 1007      | reqauth        |
+-----------+----------------+
| 1008      | reqauth        |
+-----------+----------------+
| 1009      | reqauth        |
+-----------+----------------+
| 1100      | reqauth        |
+-----------+----------------+
| 1200      | reqauth        |
+-----------+----------------+
| 1300      | reqauth        |
+-----------+----------------+
| 1400      | reqauth        |
+-----------+----------------+
| 2000      | reqauth        |
+-----------+----------------+
INFO:root:Total time: 0:01:24.847823
```