### PR TITLE
Added full URI support to svmap, svcrack and svwar

### DIFF
--- a/sipvicious/libs/svhelper.py
+++ b/sipvicious/libs/svhelper.py
@@ -1154,7 +1154,10 @@ def filterTargets(targets: list):
         parsed = urlparse(target)
         if parsed.scheme != '':
             if any(parsed.scheme == i for i in ('tcp', 'tls', 'ws', 'wss')):
-                log.fatal('CRITICAL: Unsupported protocol scheme: %s' % target)
+                log.fatal('CRITICAL: Protocol scheme %s is not supported in SIPVicious OSS', parsed.scheme)
+                exit(1)
+            if parsed.scheme != 'udp':
+                log.fatal('CRITICAL: Unsupported protocol scheme: %s', target)
                 exit(1)
             if ':' in parsed.netloc:
                 log.fatal('CRITICAL: URI %s cannot contain port. Please use -p flag.' % target)

--- a/sipvicious/libs/svhelper.py
+++ b/sipvicious/libs/svhelper.py
@@ -24,7 +24,6 @@ __version__ = '0.3.2'
 
 import re
 import sys
-from urllib import parse
 import uuid
 import os
 import dbm

--- a/sipvicious/libs/svhelper.py
+++ b/sipvicious/libs/svhelper.py
@@ -35,7 +35,7 @@ import logging
 from random import getrandbits
 from urllib.request import urlopen
 from urllib.error import URLError
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlencode
 from binascii import Error as b2aerr
 from .pptable import to_string
 from binascii import b2a_hex, a2b_hex, hexlify
@@ -1146,26 +1146,6 @@ def getAuthHeader(pkt):
             return(_tmp[0][1])
     return None
 
-
-def filterTargets(targets: list):
-    log = logging.getLogger('filterTargets')
-    newtargets = list()
-    for target in targets:
-        parsed = urlparse(target)
-        if parsed.scheme != '':
-            if any(parsed.scheme == i for i in ('tcp', 'tls', 'ws', 'wss')):
-                log.fatal('CRITICAL: Protocol scheme %s is not supported in SIPVicious OSS', parsed.scheme)
-                exit(1)
-            if parsed.scheme != 'udp':
-                log.fatal('CRITICAL: Unsupported protocol scheme: %s', target)
-                exit(1)
-            if ':' in parsed.netloc:
-                log.fatal('CRITICAL: URI %s cannot contain port. Please use -p flag.' % target)
-                exit(1)
-            newtargets.append(parsed.netloc)
-        else:
-            newtargets.append(target)
-    return newtargets
 
 
 def check_ipv6(n):

--- a/sipvicious/svcrack.py
+++ b/sipvicious/svcrack.py
@@ -361,7 +361,7 @@ class ASipOfRedWine:
 def main():
     usage = "usage: %prog -u username [options] target\r\n"
     usage += "examples:\r\n"
-    usage += "%prog -u100 -d dictionary.txt udp://10.0.0.1:5060\r\n"
+    usage += "%prog -u100 -d dictionary.txt udp://10.0.0.1:5080\r\n"
     usage += "%prog -u100 -r1-9999 -z4 10.0.0.1\r\n"
     parser = OptionParser(usage, version="%prog v" + str(__version__) + __GPL__)
     parser.add_option("-p", "--port", dest="port", default="5060",

--- a/sipvicious/svcrack.py
+++ b/sipvicious/svcrack.py
@@ -82,8 +82,10 @@ class ASipOfRedWine:
         self.crackmode = crackmode
         self.crackargs = crackargs
         try:
-            if int(port) > 1 and int(port) <= 65535:
+            if int(port) >= 1 and int(port) <= 65535:
                 self.dsthost, self.dstport = host, int(port)
+            else:
+                raise ValueError
         except (ValueError, TypeError):
             self.log.error('port should strictly be an integer between 1 and 65535')
             exit(1)
@@ -448,7 +450,6 @@ def main():
     destport = options.port
     parsed = urlparse(args[0])
     if not parsed.scheme:
-        logging.warning('No protocol scheme supplied. Using UDP for:' % args[0])
         host = args[0]
     else:
         if any(parsed.scheme == i for i in ('tcp', 'tls', 'ws', 'wss')):

--- a/sipvicious/svcrack.py
+++ b/sipvicious/svcrack.py
@@ -31,7 +31,6 @@ import traceback
 from sys import exit
 from datetime import datetime
 from optparse import OptionParser
-from urllib import parse
 from urllib.parse import urlparse
 from sipvicious.libs.pptable import to_string
 from sipvicious.libs.svhelper import ( __version__, mysendto, reportBugToAuthor,

--- a/sipvicious/svcrack.py
+++ b/sipvicious/svcrack.py
@@ -452,9 +452,9 @@ def main():
         host = args[0]
     else:
         if any(parsed.scheme == i for i in ('tcp', 'tls', 'ws', 'wss')):
-            parser.error('Sorry, currently sipvicious OSS supports only UDP.')
+            parser.error('Protocol scheme %s is not supported in SIPVicious OSS' % parsed.scheme)
         if parsed.scheme != 'udp':
-            parser.error('Invalid protocol scheme: %s' % args[0])
+            parser.error('Invalid protocol scheme: %s' % parsed.scheme)
 
         if ':' not in parsed.netloc:
             parser.error('You have to supply hosts in format of scheme://host:port when using newer convention.')

--- a/sipvicious/svmap.py
+++ b/sipvicious/svmap.py
@@ -35,7 +35,7 @@ from sipvicious.libs.pptable import to_string
 from sipvicious.libs.svhelper import (
     __version__, calcloglevel, createTag, fingerPrintPacket, getranges,
     getTag, getTargetFromSRV, ip4range, makeRequest, getRange, scanlist, ip6range,
-    mysendto, packetcounter, reportBugToAuthor, dbexists, filterTargets, check_ipv6,
+    mysendto, packetcounter, reportBugToAuthor, dbexists, check_ipv6,
     scanrandom, standardoptions, standardscanneroptions, resumeFromIP, scanfromdb
 )
 
@@ -293,7 +293,7 @@ def main():
     usage += 'Scans for SIP devices on a given network\r\n\r\n'
     usage += "examples:\r\n\r\n"
     usage += "%prog 10.0.0.1-10.0.0.255 "
-    usage += "udp://172.16.131.1 sipvicious.org/22 10.0.1.1/24"
+    usage += "172.16.131.1 sipvicious.org/22 10.0.1.1/24"
     usage += "1.1.1.1-20 1.1.2-20.* 4.1.*.*\r\n\r\n"
     usage += "%prog -s session1 --randomize 10.0.0.1/8\r\n\r\n"
     usage += "%prog --resume session1 -v\r\n\r\n"
@@ -327,7 +327,6 @@ def main():
                       help="specify a name for the from header")
     parser.add_option('-6', '--ipv6', dest="ipv6", action='store_true', help="scan an IPv6 address")
     options, args = parser.parse_args()
-    args = filterTargets(args)
     exportpath = None
     if options.resume is not None:
         exportpath = os.path.join(os.path.expanduser('~'),'.sipvicious',__prog__,options.resume)

--- a/sipvicious/svwar.py
+++ b/sipvicious/svwar.py
@@ -82,8 +82,10 @@ class TakeASip:
         self.challenges = list()
         self.realm = None
         try:
-            if int(port) > 1 and int(port) <= 65535:
+            if int(port) >= 1 and int(port) <= 65535:
                 self.dsthost, self.dstport = host, int(port)
+            else:
+                raise ValueError
         except (ValueError, TypeError):
             self.log.error('port should strictly be an integer between 1 and 65535')
             exit(1)
@@ -543,7 +545,6 @@ def main():
     destport = options.port
     parsed = urlparse(args[0])
     if not parsed.scheme:
-        logging.warning('No protocol scheme supplied. Using UDP for:' % args[0])
         host = args[0]
     else:
         if any(parsed.scheme == i for i in ('tcp', 'tls', 'ws', 'wss')):

--- a/sipvicious/svwar.py
+++ b/sipvicious/svwar.py
@@ -465,7 +465,7 @@ class TakeASip:
 def main():
     usage = "usage: %prog [options] target\r\n"
     usage += "examples:\r\n"
-    usage += "%prog -e100-999 udp://10.0.0.1:5060\r\n"
+    usage += "%prog -e100-999 udp://10.0.0.1:5080\r\n"
     usage += "%prog -d dictionary.txt 10.0.0.2\r\n"
     parser = OptionParser(usage, version="%prog v" +
         str(__version__) + __GPL__)

--- a/sipvicious/svwar.py
+++ b/sipvicious/svwar.py
@@ -547,9 +547,9 @@ def main():
         host = args[0]
     else:
         if any(parsed.scheme == i for i in ('tcp', 'tls', 'ws', 'wss')):
-            parser.error('Sorry, currently sipvicious OSS supports only UDP.')
+            parser.error('Protocol scheme %s is not supported in SIPVicious OSS' % parsed.scheme)
         if parsed.scheme != 'udp':
-            parser.error('Invalid protocol scheme: %s' % args[0])
+            parser.error('Invalid protocol scheme: %s' % parsed.scheme)
 
         if ':' not in parsed.netloc:
             parser.error('You have to supply hosts in format of scheme://host:port when using newer convention.')


### PR DESCRIPTION
### Objective
This PR addresses URI support for:
- [x] svmap: supports `udp://host` format.
- [x] svcrack: supports `udp://host:port` format.
- [x] svwar: supports `udp://host:port` format. 

### Output
Below are some exemplary usages from `svmap`, `svwar` & `svcrack`:
```bash
$ sipvicious_svmap udp://demo.sipvicious.pro

+---------------------+---------------------------------+
| SIP Device          | User Agent                      |
+=====================+=================================+
| 172.104.142.43:5060 | kamailio (5.4.4 (x86_64/linux)) |
+---------------------+---------------------------------+

$ sipvicious_svwar udp://demo.sipvicious.pro:5060 -e 1000-2000

+-----------+----------------+
| Extension | Authentication |
+===========+================+
| 1000      | reqauth        |
+-----------+----------------+
| 1001      | reqauth        |
+-----------+----------------+
| 1002      | reqauth        |
+-----------+----------------+
| 1003      | reqauth        |
+-----------+----------------+
| 1004      | reqauth        |
+-----------+----------------+
| 1005      | reqauth        |
+-----------+----------------+
| 1006      | reqauth        |
+-----------+----------------+
| 1007      | reqauth        |
+-----------+----------------+
| 1008      | reqauth        |
+-----------+----------------+
| 1009      | reqauth        |
+-----------+----------------+
| 1100      | reqauth        |
+-----------+----------------+
| 1200      | reqauth        |
+-----------+----------------+
| 1400      | reqauth        |
+-----------+----------------+
| 2000      | reqauth        |
+-----------+----------------+

$ sipvicious_svcrack udp://demo.sipvicious.pro:5060 -u 1000 -r 1400-1600

+-----------+----------+
| Extension | Password |
+===========+==========+
| 1000      | 1500     |
+-----------+----------+
```