### PR TITLE
Hotfix for UnboundLocalError in svcrack and svwar

### DIFF
--- a/sipvicious/svcrack.py
+++ b/sipvicious/svcrack.py
@@ -475,7 +475,8 @@ def main():
             try:
                 dictionary = open(options.dictionary, 'r', encoding='utf-8', errors='ignore')
             except IOError:
-                logging.error("could not open %s" % options.dictionary)
+                logging.fatal("could not open %s" % options.dictionary)
+                exit(1)
             if options.resume is not None:
                 lastpasswdsrc = os.path.join(exportpath, 'lastpasswd.pkl')
                 previousposition = pickle.load(open(lastpasswdsrc, 'rb'), encoding='bytes')

--- a/sipvicious/svwar.py
+++ b/sipvicious/svwar.py
@@ -567,7 +567,7 @@ def main():
             try:
                 dictionary = open(options.dictionary, 'r', encoding='utf-8', errors='ignore')
             except IOError:
-                logging.error("could not open %s" % options.dictionary)
+                logging.fatal("could not open %s" % options.dictionary)
                 exit(1)
             if options.resume is not None:
                 lastextensionsrc = os.path.join(exportpath, 'lastextension.pkl')


### PR DESCRIPTION
We exit if a dictionary file is not found. Earlier is a non-existent dictionary file was used it resulted in:
```bash
$ sipvicious_svcrack udp://demo.sipvicious.pro:5060 -d tesaaat.txt -u 1000
CRITICAL:root:could not open tesaaat.txt
Traceback (most recent call last):
  File "/usr/local/bin/sipvicious_svcrack", line 33, in <module>
    sys.exit(load_entry_point('sipvicious==0.3.3', 'console_scripts', 'sipvicious_svcrack')())
  File "/usr/local/lib/python3.8/dist-packages/sipvicious-0.3.3-py3.8.egg/sipvicious/svcrack.py", line 483, in main
UnboundLocalError: local variable 'dictionary' referenced before assignment
```
Now:
```bash
$ sipvicious_svcrack udp://demo.sipvicious.pro:5060 -d tesaaat.txt -u 1000
CRITICAL:root:could not open tesaaat.txt
```