### PR TITLE
Exit codes implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build
 dist
 include
 lib
+__pycache__
 distribute.egg-info
 setuptools.egg-info
 .coverage

--- a/sipvicious/libs/svhelper.py
+++ b/sipvicious/libs/svhelper.py
@@ -718,6 +718,7 @@ def ip6range(*args):
 
 
 def getranges(ipstring):
+    from sipvicious import svmap
     log = logging.getLogger('getranges')
     if re.match(
         r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}-\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$',
@@ -744,6 +745,7 @@ def getranges(ipstring):
             naddr2 = naddr1
         except socket.error:
             log.error('Could not resolve %s' % ipstring)
+            svmap.__exitcode__ = 30  # network error
             return
     return((naddr1, naddr2))
 

--- a/sipvicious/libs/svhelper.py
+++ b/sipvicious/libs/svhelper.py
@@ -1017,7 +1017,6 @@ def outputtopdf(outputfile, title, labels, db, resdb):
         from reportlab.platypus import TableStyle, Table, SimpleDocTemplate, Paragraph
         from reportlab.lib import colors
         from reportlab.lib.styles import getSampleStyleSheet
-        from reportlab.pdfgen import canvas
     except ImportError:
         log.error(
             'Reportlab was not found. To export to pdf you need to have reportlab installed. Check out www.reportlab.org')

--- a/sipvicious/libs/svhelper.py
+++ b/sipvicious/libs/svhelper.py
@@ -31,6 +31,7 @@ import socket
 import random
 import struct
 import shutil
+import optparse
 import logging
 from random import getrandbits
 from urllib.request import urlopen
@@ -44,6 +45,13 @@ if sys.hexversion < 0x03060000:
     sys.stderr.write(
         "Please update to python 3.6 or greater to run SIPVicious\r\n")
     sys.exit(1)
+
+
+class ArgumentParser(optparse.OptionParser):
+    def error(self, message, code):
+        print(self.get_usage())
+        sys.stderr.write('error: %s\r\n' % message)
+        sys.exit(code)
 
 
 def standardoptions(parser):
@@ -75,6 +83,12 @@ def standardscanneroptions(parser):
     parser.add_option("-c", "--enablecompact", dest="enablecompact", default=False, action="store_true",
                       help="enable compact mode. Makes packets smaller but possibly less compatible")
     return parser
+
+
+def resolveexitcode(newint, existingcode):
+    if existingcode > newint:
+        return existingcode
+    return newint
 
 
 def calcloglevel(options):

--- a/sipvicious/svcrack.py
+++ b/sipvicious/svcrack.py
@@ -580,7 +580,6 @@ def main():
 
     except KeyboardInterrupt:
         logging.warning('caught your control^c - quiting')
-        __exitcode__ = resolveexitcode(30, __exitcode__)
 
     except Exception as err:
         if options.reportBack:

--- a/sipvicious/svcrack.py
+++ b/sipvicious/svcrack.py
@@ -244,6 +244,7 @@ class ASipOfRedWine:
         while 1:
             if self.localport > 65535:
                 self.log.critical("Could not bind to any port")
+                __exitcode__ = resolveexitcode(30, __exitcode__)
                 return
             try:
                 self.sock.bind((self.bindingip, self.localport))

--- a/sipvicious/svcrack.py
+++ b/sipvicious/svcrack.py
@@ -29,19 +29,18 @@ import time
 import os
 import pickle
 import traceback
-from sys import exit
 from datetime import datetime
-from optparse import OptionParser
 from urllib.parse import urlparse
 from sipvicious.libs.pptable import to_string
 from sipvicious.libs.svhelper import ( __version__, mysendto, reportBugToAuthor,
-    numericbrute, dictionaryattack, packetcounter, check_ipv6,
-    createTag, makeRequest, getAuthHeader, getNonce, getOpaque,
+    numericbrute, dictionaryattack, packetcounter, check_ipv6, resolveexitcode,
+    createTag, makeRequest, getAuthHeader, getNonce, getOpaque, ArgumentParser,
     getAlgorithm, getQop, getCID, getRealm, getCredentials, getRange,
     standardscanneroptions, standardoptions, calcloglevel, resumeFrom
 )
 
 __prog__ = 'svcrack'
+__exitcode__ = 0
 
 class ASipOfRedWine:
 
@@ -88,7 +87,7 @@ class ASipOfRedWine:
                 raise ValueError
         except (ValueError, TypeError):
             self.log.error('port should strictly be an integer between 1 and 65535')
-            exit(1)
+            sys.exit(10)
         self.domain = self.dsthost
         if domain:
             self.domain = domain
@@ -165,8 +164,7 @@ class ASipOfRedWine:
         register = makeRequest(
             m,
             '"%s" <sip:%s@%s>' % (extension, extension, domain),
-            '"%s" <sip:%s@%s>' % (
-                extension, extension, domain),
+            '"%s" <sip:%s@%s>' % (extension, extension, domain),
             domain,
             self.dstport,
             callid=cid,
@@ -174,6 +172,7 @@ class ASipOfRedWine:
             branchunique=branchunique,
             cseq=cseq,
             auth=auth,
+            contact=contact,
             localtag=localtag,
             compact=self.compact,
             localport=self.localport,
@@ -235,11 +234,13 @@ class ASipOfRedWine:
             self.nomore = True
 
     def start(self):
+        global __exitcode__
         if self.bindingip == '':
             bindingip = 'any'
         else:
             bindingip = self.bindingip
         self.log.debug("binding to %s:%s" % (bindingip, self.localport))
+
         while 1:
             if self.localport > 65535:
                 self.log.critical("Could not bind to any port")
@@ -250,6 +251,7 @@ class ASipOfRedWine:
             except socket.error:
                 self.log.debug("could not bind to %s" % self.localport)
                 self.localport += 1
+
         if self.originallocalport != self.localport:
             self.log.warning("could not bind to %s:%s - some process might already be listening on this port. Listening on port %s instead" %
                           (self.bindingip, self.originallocalport, self.localport))
@@ -262,18 +264,24 @@ class ASipOfRedWine:
             mysendto(self.sock, data, (self.dsthost, self.dstport))
         except socket.error as err:
             self.log.error("socket error: %s" % err)
+            __exitcode__ = resolveexitcode(30, __exitcode__)
             return
+
         try:
             self.getResponse()
             self.lastrecvtime = time.time()
         except socket.timeout:
             self.log.error("no server response")
+            __exitcode__ = resolveexitcode(30, __exitcode__)
             return
         except socket.error as err:
             self.log.error("socket error:%s" % err)
+            __exitcode__ = resolveexitcode(30, __exitcode__)
             return
+
         if self.noauth is True:
             return
+
         while 1:
             r, _, _ = select.select(
                 self.rlist,
@@ -290,6 +298,7 @@ class ASipOfRedWine:
                     self.lastrecvtime = time.time()
                 except socket.error as err:
                     self.log.warning("socket error: %s" % err)
+                    __exitcode__ = resolveexitcode(30, __exitcode__)
             else:
                 # check if its been a while since we had a response to prevent
                 # flooding - otherwise stop
@@ -298,8 +307,11 @@ class ASipOfRedWine:
                     self.nomore = True
                     self.log.warning(
                         'It has been %s seconds since we last received a response - stopping' % timediff)
+
                 if self.passwordcracked:
+                    __exitcode__ = resolveexitcode(40, __exitcode__)
                     break
+
                 if self.nomore is True:
                     try:
                         while not self.passwordcracked:
@@ -347,25 +359,30 @@ class ASipOfRedWine:
                                         os.path.join(self.sessionpath, 'lastpasswd.pkl'), 'wb+'))
                                     self.log.debug(
                                         'logged last extension %s' % self.previouspassword)
+
                                 elif self.crackmode == 2:
                                     pickle.dump(self.crackargs.tell(), open(
                                         os.path.join(self.sessionpath, 'lastpasswd.pkl'), 'wb+'))
                                     self.log.debug(
                                         'logged last position %s' % self.crackargs.tell())
+
                             except IOError:
-                                self.log.warning(
-                                    'could not log the last extension scanned')
+                                self.log.warning('could not log the last extension scanned')
+                                __exitcode__ = resolveexitcode(20, __exitcode__)
+
                 except socket.error as err:
                     self.log.error("socket error: %s" % err)
+                    __exitcode__ = resolveexitcode(30, __exitcode__)
                     break
 
 
 def main():
+    global __exitcode__
     usage = "usage: %prog -u username [options] target\r\n"
     usage += "examples:\r\n"
-    usage += "%prog -u100 -d dictionary.txt udp://10.0.0.1:5080\r\n"
-    usage += "%prog -u100 -r1-9999 -z4 10.0.0.1\r\n"
-    parser = OptionParser(usage, version="%prog v" + str(__version__) + __GPL__)
+    usage += "\t%prog -u 100 -d dictionary.txt udp://10.0.0.1:5080\r\n"
+    usage += "\t%prog -u 100 -r1-9999 -z4 10.0.0.1\r\n"
+    parser = ArgumentParser(usage, version="%prog v" + str(__version__) + __GPL__)
     parser.add_option("-p", "--port", dest="port", default="5060",
         help="Destination port of the SIP device - eg -p 5060", metavar="PORT")
     parser = standardoptions(parser)
@@ -402,26 +419,29 @@ def main():
         help="force the first line URI to a specific value; e.g. sip:999@example.org")
     parser.add_option('-6', dest="ipv6", action="store_true", help="Scan an IPv6 address")
     parser.add_option('-m','--method', dest='method', default='REGISTER', help="Specify a SIP method to use")
+
     options, args = parser.parse_args()
+
     exportpath = None
     logging.basicConfig(level=calcloglevel(options))
     logging.debug('started logging')
+
     if options.resume is not None:
         exportpath = os.path.join(os.path.expanduser(
             '~'), '.sipvicious', __prog__, options.resume)
         if os.path.exists(os.path.join(exportpath, 'closed')):
-            logging.error("Cannot resume a session that is complete")
-            exit(1)
+            parser.error("Cannot resume a session that is complete", 20)
+
         if not os.path.exists(exportpath):
-            logging.critical(
-                'A session with the name %s was not found' % options.resume)
-            exit(1)
+            parser.error('A session with the name %s was not found' % options.resume, 20)
+
         optionssrc = os.path.join(exportpath, 'options.pkl')
         previousresume = options.resume
         previousverbose = options.verbose
         options, args = pickle.load(open(optionssrc, 'rb'), encoding='bytes')
         options.resume = previousresume
         options.verbose = previousverbose
+
     elif options.save is not None:
         exportpath = os.path.join(os.path.expanduser(
             '~'), '.sipvicious', __prog__, options.save)
@@ -431,21 +451,22 @@ def main():
         exportpath = os.path.join(os.path.expanduser(
             '~'), '.sipvicious', __prog__, options.resume)
         if not os.path.exists(exportpath):
-            logging.critical(
-                'A session with the name %s was not found' % options.resume)
-            exit(1)
+            parser.error('A session with the name %s was not found' % options.resume, 20)
+
         optionssrc = os.path.join(exportpath, 'options.pkl')
         previousresume = options.resume
         previousverbose = options.verbose
+
         options, args = pickle.load(open(optionssrc, 'rb'), encoding='bytes')
         options.resume = previousresume
         options.verbose = previousverbose
+
     elif options.save is not None:
         exportpath = os.path.join(os.path.expanduser(
             '~'), '.sipvicious', __prog__, options.save)
 
     if len(args) != 1:
-        parser.error("Please provide at least one hostname which talks SIP!")
+        parser.error("Please provide at least one hostname which talks SIP!", 10)
 
     destport = options.port
     parsed = urlparse(args[0])
@@ -453,19 +474,22 @@ def main():
         host = args[0]
     else:
         if any(parsed.scheme == i for i in ('tcp', 'tls', 'ws', 'wss')):
-            parser.error('Protocol scheme %s is not supported in SIPVicious OSS' % parsed.scheme)
+            parser.error('Protocol scheme %s is not supported in SIPVicious OSS' % parsed.scheme, 10)
+
         if parsed.scheme != 'udp':
-            parser.error('Invalid protocol scheme: %s' % parsed.scheme)
+            parser.error('Invalid protocol scheme: %s' % parsed.scheme, 10)
 
         if ':' not in parsed.netloc:
-            parser.error('You have to supply hosts in format of scheme://host:port when using newer convention.')
+            parser.error('You have to supply hosts in format of scheme://host:port when using newer convention.', 10)
+
         if int(destport) != 5060:
-            parser.error('You cannot supply additional -p when already including a port in URI. Please use only one.')
+            parser.error('You cannot supply additional -p when already including a port in URI. Please use only one.', 10)
+
         host = parsed.netloc.split(':')[0]
         destport = parsed.netloc.split(':')[1]
 
     if options.username is None:
-        parser.error("Please provide at least one username to crack!")
+        parser.error("Please provide at least one username to crack!", 10)
 
     if options.dictionary is not None:
         crackmode = 2
@@ -475,12 +499,14 @@ def main():
             try:
                 dictionary = open(options.dictionary, 'r', encoding='utf-8', errors='ignore')
             except IOError:
-                logging.error("could not open %s" % options.dictionary)
+                parser.error("could not open %s" % options.dictionary, 20)
+
             if options.resume is not None:
                 lastpasswdsrc = os.path.join(exportpath, 'lastpasswd.pkl')
                 previousposition = pickle.load(open(lastpasswdsrc, 'rb'), encoding='bytes')
                 dictionary.seek(previousposition)
         crackargs = dictionary
+
     else:
         crackmode = 1
         if options.resume is not None:
@@ -488,38 +514,42 @@ def main():
             try:
                 previouspasswd = pickle.load(open(lastpasswdsrc, 'rb'), encoding='bytes')
             except IOError:
-                logging.critical('Could not read from %s' % lastpasswdsrc)
-                exit(1)
+                parser.error('Could not read from %s' % lastpasswdsrc, 20)
+
             logging.debug('Previous range: %s' % options.range)
             options.range = resumeFrom(previouspasswd, options.range)
             logging.debug('New range: %s' % options.range)
             logging.info('Resuming from %s' % previouspasswd)
+
         rangelist = getRange(options.range)
         crackargs = (rangelist, options.zeropadding,
                      options.template, options.defaults, [options.username])
+
     if options.save is not None:
         if options.resume is None:
             exportpath = os.path.join(os.path.expanduser(
                 '~'), '.sipvicious', __prog__, options.save)
+
             if os.path.exists(exportpath):
-                logging.warning(
-                    'we found a previous scan with the same name. Please choose a new session name')
-                exit(1)
+                parser.error('we found a previous scan with the same name. Please choose a new session name', 20)
+
             logging.debug('creating an export location %s' % exportpath)
+
             try:
                 os.makedirs(exportpath, mode=0o700)
             except OSError:
-                logging.critical(
-                    'could not create the export location %s' % exportpath)
-                exit(1)
+                parser.error('could not create the export location %s' % exportpath, 20)
+
             optionsdst = os.path.join(exportpath, 'options.pkl')
             logging.debug('saving options to %s' % optionsdst)
             pickle.dump([options, args], open(optionsdst, 'wb+'))
+
     if options.autogetip:
         tmpsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         tmpsocket.connect(("msn.com", 80))
         options.externalip = tmpsocket.getsockname()[0]
         tmpsocket.close()
+
     sipvicious = ASipOfRedWine(
         host,
         username=options.username,
@@ -546,8 +576,11 @@ def main():
         sipvicious.start()
         if exportpath is not None:
             open(os.path.join(exportpath, 'closed'), 'w').close()
+
     except KeyboardInterrupt:
         logging.warning('caught your control^c - quiting')
+        __exitcode__ = resolveexitcode(30, __exitcode__)
+
     except Exception as err:
         if options.reportBack:
             logging.critical(
@@ -558,6 +591,8 @@ def main():
                 "Unhandled exception - please run same command with the -R option to send me an automated report")
             pass
         logging.exception("Exception")
+        __exitcode__ = resolveexitcode(20, __exitcode__)
+
     if options.save is not None and sipvicious.previouspassword is not None:
         lastextensiondst = os.path.join(exportpath, 'lastpasswd.pkl')
         logging.debug('saving state to %s' % lastextensiondst)
@@ -574,6 +609,8 @@ def main():
                               sipvicious.crackargs.tell())
         except IOError:
             logging.warning('could not log the last tried password')
+            __exitcode__ = resolveexitcode(20, __exitcode__)
+
     # display results
     if not options.quiet:
         lenres = len(sipvicious.resultpasswd)
@@ -593,9 +630,11 @@ def main():
                 logging.warning("too many to print - use svreport for this")
         else:
             logging.warning("found nothing")
+
     end_time = datetime.now()
     total_time = end_time - start_time
     logging.info("Total time: %s" % total_time)
+    sys.exit(__exitcode__)
 
 if __name__ == '__main__':
     main()

--- a/sipvicious/svmap.py
+++ b/sipvicious/svmap.py
@@ -179,13 +179,13 @@ class DrinkOrSip:
         while 1:
             if self.localport > 65535:
                 self.log.critical("Could not bind to any port")
+                __exitcode__ = resolveexitcode(30, __exitcode__)
                 return
             try:
                 self.sock.bind((self.bindingip,self.localport))
                 break
             except socket.error:
                 self.log.debug("could not bind to %s" % self.localport)
-                __exitcode__ = resolveexitcode(30, __exitcode__)
                 self.localport += 1
 
         if self.originallocalport != self.localport:
@@ -228,7 +228,6 @@ class DrinkOrSip:
                                 print(buff)
                             self.getResponse(buff,srcaddr)
                     except socket.error:
-                        __exitcode__ = resolveexitcode(30, __exitcode__)
                         break
 
                 try:
@@ -346,7 +345,7 @@ def main():
     options, args = parser.parse_args()
     exportpath = None
     if options.resume is not None:
-        exportpath = os.path.join(os.path.expanduser('~'),'.sipvicious',__prog__,options.resume)
+        exportpath = os.path.join(os.path.expanduser('~'), '.sipvicious', __prog__, options.resume)
 
         if os.path.exists(os.path.join(exportpath,'closed')):
             parser.error("Cannot resume a session that is complete", 20)
@@ -363,7 +362,7 @@ def main():
         options.verbose = previousverbose
 
     elif options.save is not None:
-        exportpath = os.path.join(os.path.expanduser('~'),'.sipvicious',__prog__,options.save)
+        exportpath = os.path.join(os.path.expanduser('~'), '.sipvicious', __prog__, options.save)
 
     logging.basicConfig(level=calcloglevel(options))
     logging.debug('started logging')
@@ -541,7 +540,7 @@ def main():
             logging.critical( "Unhandled exception - please run same command with the -R option to send me an automated report")
             pass
         logging.exception("Exception")
-        __exitcode__ = resolveexitcode(30, __exitcode__)
+        __exitcode__ = resolveexitcode(20, __exitcode__)
 
     if options.save is not None and sipvicious.nextip is not None and options.randomize is False and options.randomscan is False:
         lastipdst = os.path.join(exportpath,'lastip.pkl')

--- a/sipvicious/svmap.py
+++ b/sipvicious/svmap.py
@@ -30,16 +30,16 @@ import traceback
 from struct import pack
 from sys import exit
 from datetime import datetime
-from optparse import OptionParser
 from sipvicious.libs.pptable import to_string
 from sipvicious.libs.svhelper import (
-    __version__, calcloglevel, createTag, fingerPrintPacket, getranges,
+    ArgumentParser, __version__, calcloglevel, createTag, fingerPrintPacket, getranges,
     getTag, getTargetFromSRV, ip4range, makeRequest, getRange, scanlist, ip6range,
-    mysendto, packetcounter, reportBugToAuthor, dbexists, check_ipv6,
+    mysendto, packetcounter, reportBugToAuthor, dbexists, check_ipv6, resolveexitcode,
     scanrandom, standardoptions, standardscanneroptions, resumeFromIP, scanfromdb
 )
 
 __prog__ = "svmap"
+__exitcode__ = 0
 
 class DrinkOrSip:
     def __init__(self,scaniter,selecttime=0.005,compact=False, bindingip='',
@@ -166,6 +166,7 @@ class DrinkOrSip:
             self.log.debug('Packet: %s' % buff.__repr__())
 
     def start(self):
+        global __exitcode__
         # bind to 5060 - the reason is to maximize compatability with
         # devices that disregard the source port and send replies back
         # to port 5060
@@ -174,6 +175,7 @@ class DrinkOrSip:
         else:
             bindingip = self.bindingip
         self.log.debug("binding to %s:%s" % (bindingip, self.localport))
+
         while 1:
             if self.localport > 65535:
                 self.log.critical("Could not bind to any port")
@@ -183,17 +185,20 @@ class DrinkOrSip:
                 break
             except socket.error:
                 self.log.debug("could not bind to %s" % self.localport)
+                __exitcode__ = resolveexitcode(30, __exitcode__)
                 self.localport += 1
+
         if self.originallocalport != self.localport:
             self.log.warning("could not bind to %s:%s - some process might already be listening on this port. Listening on port %s instead" % (self.bindingip,self.originallocalport, self.localport))
             self.log.info("Make use of the -P option to specify a port to bind to yourself")
+
         while 1:
             r, _, _ = select.select(
                 self.rlist,
                 self.wlist,
                 self.xlist,
                 self.selecttime
-                )
+            )
             if r:
                 # we got stuff to read off the socket
                 try:
@@ -205,8 +210,10 @@ class DrinkOrSip:
                         print(srcaddr)
                         print(buff)
                 except socket.error:
+                    __exitcode__ = resolveexitcode(30, __exitcode__)
                     continue
                 self.getResponse(buff,srcaddr)
+
             else:
                 # no stuff to read .. its our turn to send back something
                 if self.nomoretoscan:
@@ -221,18 +228,22 @@ class DrinkOrSip:
                                 print(buff)
                             self.getResponse(buff,srcaddr)
                     except socket.error:
+                        __exitcode__ = resolveexitcode(30, __exitcode__)
                         break
+
                 try:
                     nextscan = next(self.scaniter)
                 except StopIteration:
                     self.log.debug('no more hosts to scan')
                     self.nomoretoscan = True
                     continue
+
                 dstip,dstport,method = nextscan
                 self.nextip = dstip
                 dsthost = (dstip,dstport)
                 domain = dsthost[0]
                 branchunique = '%s' % random.getrandbits(32)
+
                 if self.ipv6 and check_ipv6(dsthost[0]):
                     domain = '[' + dsthost[0] + ']'
                     localtag = createTag('%s%s' % (''.join(map(lambda x:
@@ -240,135 +251,148 @@ class DrinkOrSip:
                 else:
                     localtag = createTag('%s%s' % (''.join(map(lambda x:
                         '%02x' % int(x), dsthost[0].split('.'))),'%04x' % dsthost[1]))
+
                 if self.ipv6:
                     fromaddr = '"%s"<sip:100@%s>' % (self.fromname, domain)
                 else:
                     fromaddr = '"%s"<%s>' % (self.fromname, self.fromaddr)
+
                 toaddr = fromaddr
                 callid = '%s' % random.getrandbits(80)
                 contact = None
                 if method != 'REGISTER':
                     contact = 'sip:%s@%s:%s' % (self.extension,self.externalip,self.localport)
                 data = makeRequest(
-                                method,
-                                fromaddr,
-                                toaddr,
-                                domain,
-                                dsthost[1],
-                                callid,
-                                self.externalip,
-                                branchunique,
-                                compact=self.compact,
-                                localtag=localtag,
-                                contact=contact,
-                                accept='application/sdp',
-                                localport=self.localport,
-                                extension=self.extension
-                                )
+                    method,
+                    fromaddr,
+                    toaddr,
+                    domain,
+                    dsthost[1],
+                    callid,
+                    self.externalip,
+                    branchunique,
+                    compact=self.compact,
+                    localtag=localtag,
+                    contact=contact,
+                    accept='application/sdp',
+                    localport=self.localport,
+                    extension=self.extension
+                )
+
                 try:
                     self.log.debug("sending packet to %s:%s" % dsthost)
                     self.log.debug("packet: %s" % data.__repr__())
                     mysendto(self.sock,data,dsthost)
                     self.sentpackets += 1
-                    #self.sock.sendto(data,dsthost)
+
                     if self.sessionpath is not None:
                         if next(self.packetcount):
                             try:
-                                f=open(os.path.join(self.sessionpath,'lastip.pkl'),'wb+')
+                                f = open(os.path.join(self.sessionpath,'lastip.pkl'),'wb+')
                                 pickle.dump(self.nextip,f)
                                 f.close()
                                 self.log.debug('logged last ip %s' % self.nextip)
                             except IOError:
                                 self.log.warning('could not log the last ip scanned')
+                                __exitcode__ = resolveexitcode(20, __exitcode__)
+
                     if self.first is not None:
                         if self.sentpackets >= self.first:
                             self.log.info('Reached the limit to scan the first %s packets' % self.first)
                             self.nomoretoscan = True
+
                 except socket.error as err:
-                    self.log.error( "socket error while sending to %s:%s -> %s" % (dsthost[0],dsthost[1],err))
+                    self.log.error("socket error while sending to %s:%s -> %s" % (dsthost[0], dsthost[1], err))
+                    __exitcode__ = resolveexitcode(30, __exitcode__)
                     pass
 
 def main():
+    global __exitcode__
     usage = "usage: %prog [options] host1 host2 hostrange\r\n"
     usage += 'Scans for SIP devices on a given network\r\n\r\n'
-    usage += "examples:\r\n\r\n"
-    usage += "%prog 10.0.0.1-10.0.0.255 "
+    usage += "examples:\r\n"
+    usage += "\t%prog 10.0.0.1-10.0.0.255 "
     usage += "172.16.131.1 sipvicious.org/22 10.0.1.1/24"
-    usage += "1.1.1.1-20 1.1.2-20.* 4.1.*.*\r\n\r\n"
-    usage += "%prog -s session1 --randomize 10.0.0.1/8\r\n\r\n"
-    usage += "%prog --resume session1 -v\r\n\r\n"
-    usage += "%prog -p5060-5062 10.0.0.3-20 -m INVITE\r\n\r\n"
-    parser = OptionParser(usage, version="%prog v"+str(__version__)+__GPL__)
+    usage += "1.1.1.1-20 1.1.2-20.* 4.1.*.*\r\n"
+    usage += "\t%prog -s session1 --randomize 10.0.0.1/8\r\n"
+    usage += "\t%prog --resume session1 -v\r\n"
+    usage += "\t%prog -p5060-5062 10.0.0.3-20 -m INVITE\r\n"
+    parser = ArgumentParser(usage, version="%prog v" + __version__ + __GPL__)
     parser.add_option("-p", "--port", dest="port", default="5060",
-                      help="Destination port or port ranges of the SIP device - eg -p5060,5061,8000-8100", metavar="PORT")
+        help="Destination port or port ranges of the SIP device - eg -p5060,5061,8000-8100", metavar="PORT")
     parser = standardoptions(parser)
     parser = standardscanneroptions(parser)
-    parser.add_option("--randomscan", dest="randomscan", action="store_true",
-                      default=False, help="Scan random IP addresses")
+    parser.add_option("--randomscan", dest="randomscan", action="store_true", default=False, help="Scan random IP addresses")
     parser.add_option("-i", "--input", dest="input",
-                  help="Scan IPs which were found in a previous scan. Pass the session name as the argument", metavar="scan1")
+        help="Scan IPs which were found in a previous scan. Pass the session name as the argument", metavar="scan1")
     parser.add_option("-I", "--inputtext", dest="inputtext",
-                  help="Scan IPs from a text file - use the same syntax as command line but with new lines instead of commas. Pass the file name as the argument", metavar="scan1")
+        help="Scan IPs from a text file - use the same syntax as command line but with new lines instead of commas. Pass the file name as the argument", metavar="scan1")
     parser.add_option("-m", "--method", dest="method",  help="Specify the request method - by default this is OPTIONS.",
-                  default='OPTIONS')
+        default='OPTIONS')
     parser.add_option("-d", "--debug", dest="printdebug",
-                  help="Print SIP messages received", default=False, action="store_true")
-    parser.add_option("--first", dest="first",
-                  help="Only send the first given number of messages (i.e. usually used to scan only X IPs)",
-                  type="long")
+        help="Print SIP messages received", default=False, action="store_true")
+    parser.add_option("--first", dest="first", type="long",
+        help="Only send the first given number of messages (i.e. usually used to scan only X IPs)")
     parser.add_option("-e", "--extension", dest="extension", default='100',
-                  help="Specify an extension - by default this is not set")
+        help="Specify an extension - by default this is not set")
     parser.add_option("--randomize", dest="randomize", action="store_true", default=False,
-                  help="Randomize scanning instead of scanning consecutive ip addresses")
+        help="Randomize scanning instead of scanning consecutive ip addresses")
     parser.add_option("--srv", dest="srvscan", action="store_true", default=False,
-                  help="Scan the SRV records for SIP on the destination domain name." \
-                       "The targets have to be domain names - example.org domain1.com")
+        help="Scan the SRV records for SIP on the destination domain name. The targets have to be domain names - example.org domain1.com")
     parser.add_option('--fromname',dest="fromname", default="sipvicious",
-                      help="specify a name for the from header")
+        help="specify a name for the from header")
     parser.add_option('-6', '--ipv6', dest="ipv6", action='store_true', help="scan an IPv6 address")
+
     options, args = parser.parse_args()
     exportpath = None
     if options.resume is not None:
         exportpath = os.path.join(os.path.expanduser('~'),'.sipvicious',__prog__,options.resume)
+
         if os.path.exists(os.path.join(exportpath,'closed')):
-            logging.error("Cannot resume a session that is complete")
-            exit(1)
+            parser.error("Cannot resume a session that is complete", 20)
+
         if not os.path.exists(exportpath):
-            logging.critical('A session with the name %s was not found'% options.resume)
-            exit(1)
+            parser.error('A session with the name %s was not found' % options.resume, 20)
+
         optionssrc = os.path.join(exportpath,'options.pkl')
         previousresume = options.resume
         previousverbose = options.verbose
+
         options,args = pickle.load(open(optionssrc,'rb'), encoding='bytes')
         options.resume = previousresume
         options.verbose = previousverbose
+
     elif options.save is not None:
         exportpath = os.path.join(os.path.expanduser('~'),'.sipvicious',__prog__,options.save)
+
     logging.basicConfig(level=calcloglevel(options))
     logging.debug('started logging')
     scanrandomstore = None
+
     if options.input is not None:
         db = os.path.join(os.path.expanduser('~'),'.sipvicious',__prog__,options.input,'resultua')
         if dbexists(db):
             scaniter = scanfromdb(db,options.method.split(','))
         else:
-            logging.error("the session name does not exist. Please use svreport to list existing scans")
-            exit(1)
+            parser.error("the session name does not exist. Please use svreport to list existing scans", 20)
+
     elif options.randomscan:
         logging.debug('making use of random scan')
         logging.debug('parsing range of ports: %s' % options.port)
         portrange = getRange(options.port)
-        internetranges =[[16777216,167772159],
-                        [184549376,234881023],
-                        [251658240,2130706431],
-                        [2147549184,2851995647],
-                        [2852061184,2886729727],
-                        [2886795264,3221159935],
-                        [3221226240,3227017983],
-                        [3227018240,3232235519],
-                        [3232301056,3323068415],
-                        [3323199488,3758096127]
-                        ]
+        internetranges = [
+            [16777216,167772159],
+            [184549376,234881023],
+            [251658240,2130706431],
+            [2147549184,2851995647],
+            [2852061184,2886729727],
+            [2886795264,3221159935],
+            [3221226240,3227017983],
+            [3227018240,3232235519],
+            [3232301056,3323068415],
+            [3323199488,3758096127]
+        ]
+
         scanrandomstore = '.sipviciousrandomtmp'
         resumescan = False
         if options.save is not None:
@@ -381,6 +405,7 @@ def main():
             randomstore=scanrandomstore,
             resume=resumescan
         )
+
     elif options.inputtext:
         logging.debug('Using IP addresses from input text file')
         try:
@@ -388,16 +413,17 @@ def main():
             args = f.readlines()
             f.close()
         except IOError:
-            logging.critical('Could not open %s' % options.inputtext)
-            exit(1)
+            parser.error('Could not open %s' % options.inputtext, 20)
+
         args = list(map(lambda x: x.strip(), args))
         args = [x for x in args if len(x) > 0]
+
         logging.debug('ip addresses %s' % args)
         try:
             iprange = ip4range(*args)
         except ValueError as err:
-            logging.error(err)
-            exit(1)
+            parser.error(err, 20)
+
         portrange = getRange(options.port)
         if options.randomize:
             scanrandomstore = '.sipviciousrandomtmp'
@@ -405,14 +431,15 @@ def main():
             if options.save is not None:
                 scanrandomstore = os.path.join(exportpath,'random')
                 resumescan = True
-            scaniter = scanrandom(list(map(getranges,args)),portrange,
-                options.method.split(','),randomstore=scanrandomstore,resume=resumescan)
+            scaniter = scanrandom(list(map(getranges,args)), portrange,
+                options.method.split(','), randomstore=scanrandomstore, resume=resumescan)
         else:
-            scaniter = scanlist(iprange,portrange,options.method.split(','))
+            scaniter = scanlist(iprange, portrange, options.method.split(','))
+
     else:
         if len(args) < 1:
-            parser.error('Provide at least one target')
-            exit(1)
+            parser.error('Please provide at least one target', 10)
+
         logging.debug('parsing range of ports: %s' % options.port)
         portrange = getRange(options.port)
         if options.randomize:
@@ -423,23 +450,26 @@ def main():
                 resumescan = True
             scaniter = scanrandom(list(map(getranges,args)),portrange,
                 options.method.split(','),randomstore=scanrandomstore,resume=resumescan)
+
         elif options.srvscan:
             logging.debug("making use of SRV records")
             scaniter = getTargetFromSRV(args,options.method.split(','))
+
         else:
             if options.resume is not None:
-                lastipsrc = os.path.join(exportpath,'lastip.pkl')
+                lastipsrc = os.path.join(exportpath, 'lastip.pkl')
                 try:
-                    f=open(lastipsrc,'rb')
+                    f = open(lastipsrc, 'rb')
                     previousip = pickle.load(f, encoding='bytes')
                     f.close()
                 except IOError:
-                    logging.critical('Could not read from %s' % lastipsrc)
-                    exit(1)
+                    parser.error('Could not read from %s' % lastipsrc, 20)
+
                 logging.debug('Previous args: %s' % args)
-                args = resumeFromIP(previousip,args)
+                args = resumeFromIP(previousip, args)
                 logging.debug('New args: %s' % args)
                 logging.info('Resuming from %s' % previousip)
+
             if options.ipv6:
                 scaniter = scanlist(ip6range(*args), portrange, options.method.split(','))
             else:
@@ -447,60 +477,64 @@ def main():
                 try:
                     iprange = ip4range(*args)
                 except ValueError as err:
-                    logging.error(err)
-                    exit(1)
+                    parser.error(err, 20)
+
                 scaniter = scanlist(iprange,portrange,options.method.split(','))
+
     if options.save is not None:
         if options.resume is None:
             exportpath = os.path.join(os.path.expanduser('~'),'.sipvicious',__prog__,options.save)
             if os.path.exists(exportpath):
-                logging.warning('we found a previous scan with the same name. Please choose a new session name')
-                exit(1)
+                parser.error('we found a previous scan with the same name. Please choose a new session name', 20)
+
             logging.debug('creating an export location %s' % exportpath)
             try:
                 os.makedirs(exportpath,mode=0o700)
             except OSError:
-                logging.critical('could not create the export location %s' % exportpath)
-                exit(1)
+                parser.error('could not create the export location %s' % exportpath, 20)
+
             optionsdst = os.path.join(exportpath,'options.pkl')
             logging.debug('saving options to %s' % optionsdst)
             pickle.dump([options,args],open(optionsdst,'wb+'))
+
     try:
         options.extension
     except AttributeError:
         options.extension = None
+
     if options.autogetip:
         tmpsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         tmpsocket.connect(("msn.com",80))
         options.externalip=tmpsocket.getsockname()[0]
         tmpsocket.close()
+
     sipvicious = DrinkOrSip(
-                    scaniter,
-                    selecttime=options.selecttime,
-                    compact=options.enablecompact,
-                    localport=options.localport,
-                    externalip=options.externalip,
-                    bindingip=options.bindingip,
-                    sessionpath=exportpath,
-                    extension=options.extension,
-                    printdebug=options.printdebug,
-                    first=options.first,
-                    fromname=options.fromname,
-                    ipv6=options.ipv6,
-                    )
+        scaniter,
+        selecttime=options.selecttime,
+        compact=options.enablecompact,
+        localport=options.localport,
+        externalip=options.externalip,
+        bindingip=options.bindingip,
+        sessionpath=exportpath,
+        extension=options.extension,
+        printdebug=options.printdebug,
+        first=options.first,
+        fromname=options.fromname,
+        ipv6=options.ipv6,
+    )
     start_time = datetime.now()
-    logging.info( "start your engines" )
+    logging.info("start your engines")
+
     try:
-        try:
-            sipvicious.start()
-        except AssertionError as err:
-            logging.critical(err)
-            exit(1)
+        sipvicious.start()
         if exportpath is not None:
             open(os.path.join(exportpath,'closed'),'w').close()
+
     except KeyboardInterrupt:
         logging.warning( 'caught your control^c - quiting' )
+        __exitcode__ = resolveexitcode(20, __exitcode__)
         pass
+
     except Exception as err:
         if options.reportBack:
             logging.critical( "Got unhandled exception : sending report to author" )
@@ -508,7 +542,9 @@ def main():
         else:
             logging.critical( "Unhandled exception - please run same command with the -R option to send me an automated report")
             pass
-        logging.exception( "Exception" )
+        logging.exception("Exception")
+        __exitcode__ = resolveexitcode(30, __exitcode__)
+
     if options.save is not None and sipvicious.nextip is not None and options.randomize is False and options.randomscan is False:
         lastipdst = os.path.join(exportpath,'lastip.pkl')
         logging.debug('saving state to %s' % lastipdst)
@@ -518,6 +554,7 @@ def main():
             f.close()
         except OSError:
             logging.warning('Could not save state to %s' % lastipdst)
+
     elif options.save is None:
         if scanrandomstore is not None:
         #if options.randomize or options.randomscan:
@@ -549,6 +586,7 @@ def main():
     end_time = datetime.now()
     total_time = end_time - start_time
     logging.info("Total time: %s" %  total_time)
+    exit(__exitcode__)
 
 if __name__ == '__main__':
     main()

--- a/sipvicious/svmap.py
+++ b/sipvicious/svmap.py
@@ -532,8 +532,6 @@ def main():
 
     except KeyboardInterrupt:
         logging.warning( 'caught your control^c - quiting' )
-        __exitcode__ = resolveexitcode(20, __exitcode__)
-        pass
 
     except Exception as err:
         if options.reportBack:

--- a/sipvicious/svmap.py
+++ b/sipvicious/svmap.py
@@ -305,6 +305,11 @@ class DrinkOrSip:
                     __exitcode__ = resolveexitcode(30, __exitcode__)
                     pass
 
+        # if the number of sentpackets is not equal to the ones we received, then we know that
+        # there were packet drops, i.e. network errors :D one hack to rule 'em all ;P
+        if self.sentpackets != len(self.resultua):
+            __exitcode__ = resolveexitcode(30, __exitcode__)
+
 def main():
     global __exitcode__
     usage = "usage: %prog [options] host1 host2 hostrange\r\n"

--- a/sipvicious/svmap.py
+++ b/sipvicious/svmap.py
@@ -42,10 +42,10 @@ __prog__ = "svmap"
 __exitcode__ = 0
 
 class DrinkOrSip:
-    def __init__(self,scaniter,selecttime=0.005,compact=False, bindingip='',
-                 fromname='sipvicious',fromaddr='sip:100@1.1.1.1', extension=None,
-                 sessionpath=None,socktimeout=3,externalip=None,localport=5060,
-                 printdebug=False,first=None,fpworks=False,ipv6=False):
+    def __init__(self, scaniter, selecttime=0.005, compact=False, bindingip='',
+                 fromname='sipvicious', fromaddr='sip:100@1.1.1.1', extension=None,
+                 sessionpath=None, socktimeout=3, externalip=None, localport=5060,
+                 printdebug=False, first=None, fpworks=False, ipv6=False):
         self.log = logging.getLogger('DrinkOrSip')
         family = socket.AF_INET
         if ipv6:
@@ -97,12 +97,12 @@ class DrinkOrSip:
         else:
             self.log.debug("external ip was set")
             self.externalip = externalip
-        self.log.debug("External ip: %s:%s" % (self.externalip,localport) )
+        self.log.debug("External ip: %s:%s" % (self.externalip, localport) )
         self.compact = compact
         self.log.debug("Compact mode: %s" % self.compact)
         self.fromname = fromname
         self.fromaddr = fromaddr
-        self.log.debug("From: %s <%s>" % (self.fromname,self.fromaddr))
+        self.log.debug("From: %s <%s>" % (self.fromname, self.fromaddr))
         self.nomoretoscan = False
         self.originallocalport = self.localport
         self.nextip = None
@@ -114,7 +114,7 @@ class DrinkOrSip:
             self.packetcount = packetcounter(50)
         self.sentpackets = 0
 
-    def getResponse(self,buff,srcaddr):
+    def getResponse(self, buff, srcaddr):
         srcip, srcport, *_ = srcaddr
         uaname = 'unknown'
         buff = buff.decode('utf-8', 'ignore')
@@ -124,7 +124,7 @@ class DrinkOrSip:
             if self.externalip == srcip:
                 self.log.debug("We received our own packet from %s:%s" % (str(srcip), srcport))
             else:
-                self.log.info("Looks like we received a SIP request from %s:%s"% (str(srcip), srcport))
+                self.log.info("Looks like we received a SIP request from %s:%s" % (str(srcip), srcport))
                 self.log.debug(buff.__repr__())
             return
         self.log.debug("running fingerPrintPacket()")
@@ -151,18 +151,18 @@ class DrinkOrSip:
             try:
                 dstip = socket.inet_ntoa(pack('!L',int(originaldst[:8],16)))
                 dstport = int(originaldst[8:12],16)
-            except (ValueError,TypeError,socket.error):
+            except (ValueError, TypeError, socket.error):
                 self.log.debug("original destination could not be decoded: %s" % (originaldst))
-                dstip,dstport = 'unknown','unknown'
-            resultstr = '%s:%s\t->\t%s:%s\t->\t%s' % (dstip,dstport,srcip,srcport,uaname)
+                dstip, dstport = 'unknown','unknown'
+            resultstr = '%s:%s\t->\t%s:%s\t->\t%s' % (dstip, dstport, srcip, srcport, uaname)
             self.log.info( resultstr )
-            self.resultip['%s:%s' % (srcip,srcport)] = '%s:%s' % (dstip,dstport)
-            self.resultua['%s:%s' % (srcip,srcport)] = uaname
+            self.resultip['%s:%s' % (srcip, srcport)] = '%s:%s' % (dstip, dstport)
+            self.resultua['%s:%s' % (srcip, srcport)] = uaname
             if self.sessionpath is not None and self.dbsyncs:
                 self.resultip.sync()
                 self.resultua.sync()
         else:
-            self.log.info('Packet from %s:%s did not contain a SIP msg'%srcaddr)
+            self.log.info('Packet from %s:%s did not contain a SIP msg' % srcaddr)
             self.log.debug('Packet: %s' % buff.__repr__())
 
     def start(self):
@@ -182,14 +182,15 @@ class DrinkOrSip:
                 __exitcode__ = resolveexitcode(30, __exitcode__)
                 return
             try:
-                self.sock.bind((self.bindingip,self.localport))
+                self.sock.bind((self.bindingip, self.localport))
                 break
             except socket.error:
                 self.log.debug("could not bind to %s" % self.localport)
                 self.localport += 1
 
         if self.originallocalport != self.localport:
-            self.log.warning("could not bind to %s:%s - some process might already be listening on this port. Listening on port %s instead" % (self.bindingip,self.originallocalport, self.localport))
+            self.log.warning("could not bind to %s:%s - some process might already be listening on this port." \
+                "Listening on port %s instead" % (self.bindingip, self.originallocalport, self.localport))
             self.log.info("Make use of the -P option to specify a port to bind to yourself")
 
         while 1:
@@ -202,7 +203,7 @@ class DrinkOrSip:
             if r:
                 # we got stuff to read off the socket
                 try:
-                    buff,srcaddr = self.sock.recvfrom(8192)
+                    buff, srcaddr = self.sock.recvfrom(8192)
                     host, port, *_ = srcaddr
                     self.log.debug('got data from %s:%s' % (str(host), str(port)))
                     self.log.debug('data: %s' % buff.__repr__())
@@ -212,7 +213,7 @@ class DrinkOrSip:
                 except socket.error:
                     __exitcode__ = resolveexitcode(30, __exitcode__)
                     continue
-                self.getResponse(buff,srcaddr)
+                self.getResponse(buff, srcaddr)
 
             else:
                 # no stuff to read .. its our turn to send back something
@@ -222,11 +223,11 @@ class DrinkOrSip:
                         self.log.debug("Making sure that no packets get lost")
                         self.log.debug("Come to daddy")
                         while 1:
-                            buff,srcaddr = self.sock.recvfrom(8192)
+                            buff, srcaddr = self.sock.recvfrom(8192)
                             if self.printdebug:
                                 print(srcaddr)
                                 print(buff)
-                            self.getResponse(buff,srcaddr)
+                            self.getResponse(buff, srcaddr)
                     except socket.error:
                         break
 
@@ -237,9 +238,9 @@ class DrinkOrSip:
                     self.nomoretoscan = True
                     continue
 
-                dstip,dstport,method = nextscan
+                dstip, dstport, method = nextscan
                 self.nextip = dstip
-                dsthost = (dstip,dstport)
+                dsthost = (dstip, dstport)
                 domain = dsthost[0]
                 branchunique = '%s' % random.getrandbits(32)
 
@@ -260,7 +261,7 @@ class DrinkOrSip:
                 callid = '%s' % random.getrandbits(80)
                 contact = None
                 if method != 'REGISTER':
-                    contact = 'sip:%s@%s:%s' % (self.extension,self.externalip,self.localport)
+                    contact = 'sip:%s@%s:%s' % (self.extension, self.externalip, self.localport)
                 data = makeRequest(
                     method,
                     fromaddr,
@@ -281,14 +282,14 @@ class DrinkOrSip:
                 try:
                     self.log.debug("sending packet to %s:%s" % dsthost)
                     self.log.debug("packet: %s" % data.__repr__())
-                    mysendto(self.sock,data,dsthost)
+                    mysendto(self.sock, data, dsthost)
                     self.sentpackets += 1
 
                     if self.sessionpath is not None:
                         if next(self.packetcount):
                             try:
                                 f = open(os.path.join(self.sessionpath,'lastip.pkl'),'wb+')
-                                pickle.dump(self.nextip,f)
+                                pickle.dump(self.nextip, f)
                                 f.close()
                                 self.log.debug('logged last ip %s' % self.nextip)
                             except IOError:
@@ -362,7 +363,7 @@ def main():
         previousresume = options.resume
         previousverbose = options.verbose
 
-        options,args = pickle.load(open(optionssrc,'rb'), encoding='bytes')
+        options, args = pickle.load(open(optionssrc,'rb'), encoding='bytes')
         options.resume = previousresume
         options.verbose = previousverbose
 
@@ -374,9 +375,9 @@ def main():
     scanrandomstore = None
 
     if options.input is not None:
-        db = os.path.join(os.path.expanduser('~'),'.sipvicious',__prog__,options.input,'resultua')
+        db = os.path.join(os.path.expanduser('~'), '.sipvicious',__prog__, options.input,'resultua')
         if dbexists(db):
-            scaniter = scanfromdb(db,options.method.split(','))
+            scaniter = scanfromdb(db, options.method.split(','))
         else:
             parser.error("the session name does not exist. Please use svreport to list existing scans", 20)
 
@@ -385,16 +386,16 @@ def main():
         logging.debug('parsing range of ports: %s' % options.port)
         portrange = getRange(options.port)
         internetranges = [
-            [16777216,167772159],
-            [184549376,234881023],
-            [251658240,2130706431],
-            [2147549184,2851995647],
-            [2852061184,2886729727],
-            [2886795264,3221159935],
-            [3221226240,3227017983],
-            [3227018240,3232235519],
-            [3232301056,3323068415],
-            [3323199488,3758096127]
+            [16777216, 167772159],
+            [184549376, 234881023],
+            [251658240, 2130706431],
+            [2147549184, 2851995647],
+            [2852061184, 2886729727],
+            [2886795264, 3221159935],
+            [3221226240, 3227017983],
+            [3227018240, 3232235519],
+            [3232301056, 3323068415],
+            [3323199488, 3758096127]
         ]
 
         scanrandomstore = '.sipviciousrandomtmp'
@@ -413,7 +414,7 @@ def main():
     elif options.inputtext:
         logging.debug('Using IP addresses from input text file')
         try:
-            f = open(options.inputtext,'r')
+            f = open(options.inputtext, 'r')
             args = f.readlines()
             f.close()
         except IOError:
@@ -435,7 +436,7 @@ def main():
             if options.save is not None:
                 scanrandomstore = os.path.join(exportpath,'random')
                 resumescan = True
-            scaniter = scanrandom(list(map(getranges,args)), portrange,
+            scaniter = scanrandom(list(map(getranges, args)), portrange,
                 options.method.split(','), randomstore=scanrandomstore, resume=resumescan)
         else:
             scaniter = scanlist(iprange, portrange, options.method.split(','))
@@ -452,12 +453,12 @@ def main():
             if options.save is not None:
                 scanrandomstore = os.path.join(exportpath,'random')
                 resumescan = True
-            scaniter = scanrandom(list(map(getranges,args)),portrange,
-                options.method.split(','),randomstore=scanrandomstore,resume=resumescan)
+            scaniter = scanrandom(list(map(getranges, args)), portrange,
+                options.method.split(','), randomstore=scanrandomstore, resume=resumescan)
 
         elif options.srvscan:
             logging.debug("making use of SRV records")
-            scaniter = getTargetFromSRV(args,options.method.split(','))
+            scaniter = getTargetFromSRV(args, options.method.split(','))
 
         else:
             if options.resume is not None:
@@ -483,23 +484,23 @@ def main():
                 except ValueError as err:
                     parser.error(err, 20)
 
-                scaniter = scanlist(iprange,portrange,options.method.split(','))
+                scaniter = scanlist(iprange, portrange, options.method.split(','))
 
     if options.save is not None:
         if options.resume is None:
-            exportpath = os.path.join(os.path.expanduser('~'),'.sipvicious',__prog__,options.save)
+            exportpath = os.path.join(os.path.expanduser('~'), '.sipvicious', __prog__, options.save)
             if os.path.exists(exportpath):
                 parser.error('we found a previous scan with the same name. Please choose a new session name', 20)
 
             logging.debug('creating an export location %s' % exportpath)
             try:
-                os.makedirs(exportpath,mode=0o700)
+                os.makedirs(exportpath, mode=0o700)
             except OSError:
                 parser.error('could not create the export location %s' % exportpath, 20)
 
-            optionsdst = os.path.join(exportpath,'options.pkl')
+            optionsdst = os.path.join(exportpath, 'options.pkl')
             logging.debug('saving options to %s' % optionsdst)
-            pickle.dump([options,args],open(optionsdst,'wb+'))
+            pickle.dump([options, args], open(optionsdst, 'wb+'))
 
     try:
         options.extension
@@ -552,7 +553,7 @@ def main():
         logging.debug('saving state to %s' % lastipdst)
         try:
             f = open(lastipdst,'wb+')
-            pickle.dump(sipvicious.nextip,f)
+            pickle.dump(sipvicious.nextip, f)
             f.close()
         except OSError:
             logging.warning('Could not save state to %s' % lastipdst)
@@ -579,7 +580,7 @@ def main():
                         rows.append((k.decode(),sipvicious.resultua[k].decode()))
                 except AttributeError:
                     for k in sipvicious.resultua.keys():
-                        rows.append((k,sipvicious.resultua[k]))
+                        rows.append((k, sipvicious.resultua[k]))
                 print(to_string(rows, header=labels))
             else:
                 logging.warning("too many to print - use svreport for this")

--- a/sipvicious/svwar.py
+++ b/sipvicious/svwar.py
@@ -688,8 +688,10 @@ def main():
         sipvicious.start()
         if exportpath is not None:
             open(os.path.join(exportpath, 'closed'), 'w').close()
+
     except KeyboardInterrupt:
         logging.warning('caught your control^c - quiting')
+
     except Exception as err:
         if options.reportBack:
             logging.critical(

--- a/sipvicious/svwar.py
+++ b/sipvicious/svwar.py
@@ -386,6 +386,7 @@ class TakeASip:
                         print(buff)
                 except socket.error as err:
                     self.log.error("socket error: %s" % err)
+                    __exitcode__ = resolveexitcode(30, __exitcode__)
                     return
 
                 buff = buff.decode('utf-8', 'ignore')


### PR DESCRIPTION
This PR addresses:
- [x] Exit codes across `svmap`, `svwar`, `svcrack` as discussed.
- [x] Some code refactoring and fixing other unbound errors.

__Example:__
Few examples for `svwar`:
- network connectivity errors
  ```
  $ sipvicious_svwar demo
  ERROR:TakeASip:socket error: [Errno -3] Temporary failure in name resolution
  WARNING:root:found nothing
  
  $ echo $?
  30
  ```
- syntax errors
  ```
  $ sipvicious_svwar udp://demo.sipvicious.pro:
  ERROR:TakeASip:port should strictly be an integer between 1 and 65535
  
  $ echo $?
  10
  ```
- security issue
  ```
  $ sipvicious_svwar udp://demo.sipvicious.pro:5060 -e 1000
  +-----------+----------------+
  | Extension | Authentication |
  +===========+================+
  | 1000      | reqauth        |
  +-----------+----------------+
  
  $ echo $?
  40
  ```