### PR TITLE
Fixed digest auth issue due to target misimplementation (lack of `noncecount`)

### DIFF
--- a/sipvicious/libs/svhelper.py
+++ b/sipvicious/libs/svhelper.py
@@ -457,7 +457,7 @@ def challengeResponse(auth, method, uri):
         username, realm, nonce, uri)
     if algorithm == "md5-sess" or qop == "auth":
         cnonce = uuid.uuid4().hex
-        nonceCount = "%08d" % auth["noncecount"]
+        nonceCount = "%08d" % auth["noncecount"] if 'noncecount' in auth else '00000001'
         result += ',cnonce="%s",nc=%s' % (cnonce, nonceCount)
     if algorithm is None or algorithm == "md5":
         ha1 = md5(('%s:%s:%s' % (username, realm, passwd)).encode('utf-8')).hexdigest()


### PR DESCRIPTION
Whenever a target server gives a digest authentication challenge, sipvicious will need to respond the challenge. In some implementations, server challenge doesn't contain the `noncecount`, which leads sipvicious to unexpected behavior.

I'm not sure if this fix is the best solution or not, but it uses a default value (`00000001`) for the `noncecount` value when challenge doesn't contain it.